### PR TITLE
use group_name in the config hash 

### DIFF
--- a/lib/puppet/provider/ec2_securitygroup/v2.rb
+++ b/lib/puppet/provider/ec2_securitygroup/v2.rb
@@ -86,7 +86,7 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
   def create
     Puppet.info("Creating security group #{name} in region #{target_region}")
     config = {
-      group_name: name,
+      group_name: resource[:group_name],
       description: resource[:description]
     }
 


### PR DESCRIPTION
Explicitly use group_name parameter in the config hash, to avoid the namevar mapping to group_name. Currently no 'default' security group is created because of this issue.
