### PR TITLE
Security group group name fix

### DIFF
--- a/lib/puppet/provider/ec2_securitygroup/v2.rb
+++ b/lib/puppet/provider/ec2_securitygroup/v2.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
     Puppet.info("Creating security group #{name} in region #{resource[:region]}")
     ec2 = ec2_client(resource[:region])
     config = {
-      group_name: name,
+      group_name: resource[:group_name],
       description: resource[:description]
     }
 


### PR DESCRIPTION
Explicitly use group_name parameter in the config hash, to avoid the namevar mapping to group_name. Currently no 'default' security group is created because of this issue.
