### PR TITLE
fix s3_bucket resources not being created

### DIFF
--- a/lib/puppet/provider/s3_bucket/v2.rb
+++ b/lib/puppet/provider/s3_bucket/v2.rb
@@ -47,7 +47,10 @@ Puppet::Type.type(:s3_bucket).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) 
   end
 
   def exists?
-    self.class.instances.include? self
+    # Array#include? leads to Puppet::Provider#<=>, which does
+    # class name comparison. We need object_id comparison here,
+    # so use Kernel#eql? instead.
+    self.class.instances.find { |instance| instance.eql? self }
   end
 
   def create


### PR DESCRIPTION
A bug in `s3_bucket` causes it to believe that buckets exist when they don't.
The `exists?` method calls `include?` which (via the `Comparable` mixin) ends up using `<=>` from `Puppet::Provider`. That module redefines `<=>` to do class name comparison which is not what we want (we need strict `object_id` equality for the code to work).

This PR provides a fix based on `eql?` (from `Kernel`).
